### PR TITLE
feat: [META-966] - Document update for slow query logging

### DIFF
--- a/scst-store/logs.hbs.md
+++ b/scst-store/logs.hbs.md
@@ -34,6 +34,10 @@ extensibility.
 
 If no verbosity level is specified when the Store is installed, the level is set to `default`.
 
+### <a id='slow-sql'></a> Slow SQL
+
+Slow sql statement will be logged only when verbosity level is set to `trace` and sql query took more than 200 milliseconds to execute. You can change this default by setting `db_slow_threshold_ms` value in values.yaml file and redeploy metadata store.
+
 ### <a id='error-logs'></a> Error Logs
 
 Error logs are always outputted regardless of the verbosity level, even when set to `minimum`.
@@ -173,6 +177,89 @@ because:
 Moving the payload information at this level helps keep the production log output to a reasonable size.
 * Some information in these payloads may be sensitive, and the user may not want them exposed in
 production environment logs.
+
+##  <a id='graphql-endptlog-out'></a> GraphQL endpoint log output (Only applicable to Artifactory Metadata Repository logs)
+
+When an GraphQL endpoint handles a request, the AMR generates following types of logs. They are:
+
+1. Every request received will produce a `Processing request` log, which includes the name of the operation called and the fields that are being requested
+1. Every response will produce a log containing the actual query and the return status
+1. If the endpoint returns a response body, it outputs a second `Request response` line with an extra
+key `payload`, and its value is set to the entire response body. This line is shown at the `debug`
+   verbosity level
+
+### <a id='graphql-endptlog-out-format'></a>  Format
+
+The logs output are in JSON format.
+
+When the AMR handles a request, it outputs some GraphQL endpoint access information in the following
+format:
+
+```console
+{"level":"info","ts":"2023-03-23T13:11:31.161531-06:00","logger":"Artifact Metadata Repository","msg":"Processing request","hostname":"xyzp2DMD6R.vmware.com","getAllApps":"query getAllApps {\n  apps(latest:true) {\n    \n    timestamp\n    location {\n      alias\n    }\n  }\n}"}
+{"level":"info","ts":"2023-03-23T13:11:31.172953-06:00","logger":"Artifact Metadata Repository","msg":"Request response","hostname":"xyzp2DMD6R.vmware.com","getAllApps":"query getAllApps {\n  apps(latest:true) {\n    \n    timestamp\n    location {\n      alias\n    }\n  }\n}","code":200,"response":"OK"}
+```
+
+####  <a id='graphql_key-val'></a> Key-value pairs
+
+The following tables list the meaning of each key found in the logs.
+
+#####  <a id='graphql_common-all'></a> Common to all logs
+
+The following key-value pairs are common for all logs.
+
+| Key      | Type    | Verbosity Level | Description                                                                                                                                                                                  |
+|----------|---------|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    |
+ | level    | string  | all             | The log level of the message. This is either 'error' for error messages, or 'info' for all other messages.                                                                                  |
+| ts       | string  | all             | The timestamp when the log message was generated. It uses RFC 3339 format with nanosecond precision and 00:00 offset from  UTC, meaning Zulu time.                                           |
+| logger   | string  | all             | Used to identify what produced the log entry. For Store, the name always starts with `MetadataStore`. For log entries that display the raw SQL queries, the name is `MetadataStore.gorm`     |
+| msg      | string  | all             | A short description of the logged event.                                                                                                                                                     |
+| hostname | string  | all             | The Kubernetes hostname of the pod handling the request. This helps identify the specific instance of the Store when you deploy multiple instances on a cluster.                             |
+| error    | string  | all             | The error message which is only available in error log entries.                                                                                                                              |
+| code     | integer | default         | The HTTP response code.                                                                                                                                                                      |
+| response | string  | default         | The HTTP response in human-readable format. For example, 'OK', 'Bad Request', or 'Internal Server Error'.                                                                                    |
+| query    | string  | debug           | The operation name will be key and value field will have the fields requested                                                                                                                                                                                                                             |
+
+#####  <a id='graphql-payload-out'></a> API payload log output
+
+As mentioned at the start of this section, by setting the verbosity level to `debug`, the AMR logs the
+body payload data for both the request and response of an API call.
+
+The `debug` verbosity level, instead of the `default`, is used to display this information instead of `default`
+because:
+
+* Body payloads can be huge and some information in these payloads may be sensitive, and the user may not want them exposed in
+production environment logs.
+
+Logs containing payload information may be in below mentioned format:
+
+```console
+{"level":"info","ts":"2023-03-23T13:11:31.172966-06:00","logger":"Artifact Metadata Repository","msg":"Request response","hostname":"xyzp2DMD6R.vmware.com","getAllApps":"query getAllApps {\n  apps(latest:true) {\n    \n    timestamp\n    location {\n      alias\n    }\n  }\n}","payload":{"apps":[{"timestamp":"2023-03-22T15:09:38.867371-06:00","location":{"alias":"1-Alias"}}]}}
+```
+
+##  <a id='slow_sql_query-out'></a> Slow SQL Query log output
+When verbosity level is set to `trace` you will see log messages containing slow sql queries.
+
+>**Note** Some information in these SQL Query `trace` logs might be sensitive, and the user might not
+want them exposed in production environment logs.
+
+###  <a id='slow_sql_query-out-format'></a> SQL Query log output
+
+Slow SQL query logs will be displayed in the following format when verbosity level is set to `trace`:
+
+```console
+{"level":"info","ts":"2023-03-23T12:48:12.337749-06:00","logger":"Artifact Metadata Repository.gorm","msg":"slow sql >= 200ms","hostname":"xyzp2DMD6R.vmware.com","rows":50000,"sql":"SELECT \"artifact_apps\".\"id\",\"artifact_apps\".\"created_at\",\"artifact_apps\".\"updated_at\",\"artifact_apps\".\"deleted_at\",\"artifact_apps\".\"location_id\",\"artifact_apps\".\"correlation_id\",\"artifact_apps\".\"image_url\",\"artifact_apps\".\"image_digest\",\"artifact_apps\".\"namespace\",\"artifact_apps\".\"name\",\"artifact_apps\".\"instances\",\"artifact_apps\".\"status\",\"artifact_apps\".\"timestamp\" FROM \"artifact_apps\" INNER JOIN (select max(timestamp) as timestamp, name, namespace, location_id from artifact_apps group by location_id, name, namespace) as argo on argo.timestamp = artifact_apps.timestamp and argo.name = artifact_apps.name and argo.location_id = artifact_apps.location_id and argo.namespace = artifact_apps.namespace WHERE \"artifact_apps\".\"deleted_at\" IS NULL"}
+```
+
+It is similar to the [API endpoint log output](#api-endpoint-log-output) format, but also uses the
+following key-value pairs:
+
+| Key   | Type    | Log Level | Description                                                                                                                                                                                 |
+|-------|---------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| rows  | integer | trace     | Indicates the number of rows affected by the SQL query.                                                                                                                                     |
+| sql   | string  | trace     | Displays the raw SQL query for the database.                                                                                                                                                |
+| data# | string  | all       | Used in error log entries. You can replace `#` with an integer because multiples of these keys can appear in the same log entry. These keys contain extra information related to the error. |
+
 
 ##  <a id='sql_query-out'></a> SQL Query log output
 


### PR DESCRIPTION
Logger Documentation updated for 

- `db_slow_threshold_milliseconds`
- `GraphQL queries`

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?
This change affects 1.5.1 and above releases.
 
It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see https://github.com/pivotal/docs-tap#branches
